### PR TITLE
custom public 3scale base urls

### DIFF
--- a/docs/content/gs-adding-custom-3scale-routes.adoc
+++ b/docs/content/gs-adding-custom-3scale-routes.adoc
@@ -1,0 +1,63 @@
+[id='gs-adding-custom-3scale-routes']
+
+ifdef::env-github[]
+:imagesdir: ../images/
+endif::[]
+
+= Creating custom urls for 3scale APIs
+
+If you use 3scale to manage your API, you might require that the API URL use a specific host and format.
+For example, you might want to expose an API as `https://mydomain.com/v1/getStuff`.
+To use a custom domain, you must create a route in the OpenShift 3scale project as described below.
+
+.Prerequisites
+* you must be logged in as the `customer-admin` user
+* a custom domain registration
+
+.Procedure
+
+A new OpenShift route for the public has to be created.
+
+First make sure you are logged in as `customer-admin`
+
+```sh
+$ oc login -u customer-admin
+```
+
+Create a file named `custom-route.yaml` using the appropriate values for `<route name>` and `<route host>`:
+
+```yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: <route name>
+  namespace: openshift-3scale
+spec:
+  host: <route host>
+  port:
+    targetPort: gateway
+  tls:
+    insecureEdgeTerminationPolicy: None
+    termination: edge
+  to:
+    kind: Service
+    name: apicast-staging
+    weight: 100
+  wildcardPolicy: None
+```
+
+Create the route:
+
+```sh
+$ oc create -f ./custom-route.yaml
+```
+
+NOTE: You cannot delete any routes created using this method.
+
+.Additional Information
+
+Once the route is created in OpenShift it has to be configured in your APIcast instance.
+
+See the link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html-single/deployment_options/index#configure_your_service[3scale documentation] for a description of how to set up your public base URL in APIcast.
+
+See the link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html-single/deployment_options/index#public_base_url[Public Base URL] documentation for an introduction to custom URLs.

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -21,3 +21,5 @@ include::content/gs-writing-walkthroughs-proc.adoc[leveloffset=+1]
 include::content/gs-using-nexus-proc.adoc[leveloffset=+1]
 
 include::content/gs-custom-keycloak-idp.adoc[leveloffset=+1]
+
+include::content/gs-adding-custom-3scale-routes.adoc[leveloffset=+1]


### PR DESCRIPTION
User facing docs for setting up custom public base URLs in 3scale.

1.3 on OSD requires granting permissions to the customer-admin user first which is described in a SOP: https://github.com/integr8ly/help/pull/111