### PR TITLE
INTLY-4753: Update Links for 1.6 Release

### DIFF
--- a/modules/ROOT/pages/_partials/gs-adding-users-proc.adoc
+++ b/modules/ROOT/pages/_partials/gs-adding-users-proc.adoc
@@ -64,11 +64,11 @@ A user named `admin` is also created and is used to manage this instance. Do not
 | Permissions
 | Can create users in the `openshift` realm.
 
-Can add an Identity Provider in the `openshift` realm as described in link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/server_administration_guide/index#identity_broker[Identity Brokering] to avoid managing the same users in different realms.
+Can add an Identity Provider in the `openshift` realm as described in link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html/server_administration_guide/identity_broker[Identity Brokering] to avoid managing the same users in different realms.
 
 | Can create users in the `master` realm.
 
-Can add an Identity Provider in the `master` realm as described in link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/server_administration_guide/index#identity_broker[Identity Brokering] to avoid managing the same users in different realms.
+Can add an Identity Provider in the `master` realm as described in link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html/server_administration_guide/identity_broker[Identity Brokering] to avoid managing the same users in different realms.
 
 Can create new and manage realms.
 
@@ -146,7 +146,7 @@ NOTE: This step does not automatically send an email to new users.
 
 [NOTE]
 ====
-You can also import a JSON file with user information as described in the https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html/server_administration_guide/export_import#admin_console_export_import[Red Hat Single Sign-On documentation].
+You can also import a JSON file with user information as described in the https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html/server_administration_guide/export_import[Red Hat Single Sign-On documentation].
 ====
 
 The following example JSON file imports two users:
@@ -291,7 +291,7 @@ To delete 3scale users:
 
 This procedure describes how to add the *view* role for a user if that user requires either of the following:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html-single/service_discovery/index[Service Discovery] in 3scale, which can be used to add Fuse Online services automatically
+* link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.7/html/admin_portal_guide/service-discovery[Service Discovery] in 3scale, which can be used to add Fuse Online services automatically
 * Access to Fuse Online integration logs
 
 . Log in to OpenShift using `oc` and the `customer-admin` credentials.

--- a/modules/ROOT/pages/_partials/gs-custom-keycloak-idp.adoc
+++ b/modules/ROOT/pages/_partials/gs-custom-keycloak-idp.adoc
@@ -26,4 +26,4 @@ This section describes how to add a custom identity provider to Red Hat Single S
 
 . In the menu navigate to `Identity Providers` and pick a provider from the drop down.
 
-. Follow the instructions in the link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.2/html-single/server_administration_guide/index#identity_broker[Red Hat Single Sign-On documentation] to add a new identity provider.
+. Follow the instructions in the link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html/server_administration_guide/identity_broker[Red Hat Single Sign-On documentation] to add a new identity provider.

--- a/modules/ROOT/pages/_partials/gs-service-discovery-3scale.adoc
+++ b/modules/ROOT/pages/_partials/gs-service-discovery-3scale.adoc
@@ -22,5 +22,5 @@ $ oc adm policy add-role-to-user view <user-name> -n fuse
 
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html/service_discovery/index[Service Discovery] 3scale documentation.
-* link:https://access.redhat.com/documentation/en-us/red_hat_fuse/7.3/html/designing_apis_with_apicurito/threescale-discover-service[Service Discovery] Fuse documentation.
+* link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.7/html/admin_portal_guide/service-discovery[Service Discovery] 3scale documentation.
+* link:https://access.redhat.com/documentation/en-us/red_hat_fuse/7.4/html/designing_apis_with_apicurito/threescale-discover-service[Service Discovery] Fuse documentation.

--- a/modules/ROOT/pages/_partials/rn-new-and-changed-ref.adoc
+++ b/modules/ROOT/pages/_partials/rn-new-and-changed-ref.adoc
@@ -12,16 +12,16 @@ This release includes new versions of the following components:
 |Release Notes
 
 |{fuse-name}
-|link:https://access.redhat.com/documentation/en-us/red_hat_fuse/7.4/html/release_notes/index[{fuse-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_fuse/7.5/html/release_notes_for_red_hat_fuse_7.5/micro-release-7.5.1[{fuse-version}]
 
 |{amq-online-name}
-|link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.4/html/amq_online_1.2_on_openshift_container_platform_release_notes/[{amq-online-version}]
+|link:hhttps://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html/release_notes_for_amq_online_1.3_on_openshift/index[{amq-online-version}]
 
 |{three-scale-name}
-|link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.6/html/release_notes/index[{three-scale-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.7/html/release_notes_for_red_hat_3scale_api_management_2.7_on-premises/index[{three-scale-version}]
 
 |{code-ready-name}
-|link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/{code-ready-version}/html/release_notes_and_known_issues/index[{code-ready-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.0/html/release_notes_and_known_issues/index[{code-ready-version}]
 
 |Red Hat Single Sign-On
 |link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.3/html-single/release_notes/index[7.3]
@@ -30,8 +30,8 @@ This release includes new versions of the following components:
 
 == Solution Explorer changes
 
-The Solution Explorer home page now provides more information about the applications in your cluster, listing the goals you can accomplish with each service. 
-The Solution Patterns are now available in a separate tab, named *All Solution Patterns*.
+The Solution Explorer homepage now provides more information on the applications in your cluster, listing the goals you can accomplish with each service. 
+The Solution Patterns are available in a separate tab, named *All Solution Patterns*.
 
 In addition, you can now:
 
@@ -39,4 +39,4 @@ In addition, you can now:
 See link:{gs-link}#gs-publishing-walkthroughs-proc[Adding Solution Patterns to your cluster] for more information about navigating to a source repository.
 
 * Retrieve useful URLs for your cluster from the help menu of Solution Explorer.
-See link:{gs-link}#gs-using-developer-resources-proc[Using Developer Resources] for more information.
+See link:{gs-link}#gs-accessing-developer-resources-proc[Using Developer Resources] for more information.

--- a/modules/ROOT/pages/_partials/rn-new-and-changed-ref.adoc
+++ b/modules/ROOT/pages/_partials/rn-new-and-changed-ref.adoc
@@ -15,7 +15,7 @@ This release includes new versions of the following components:
 |link:https://access.redhat.com/documentation/en-us/red_hat_fuse/7.5/html/release_notes_for_red_hat_fuse_7.5/micro-release-7.5.1[{fuse-version}]
 
 |{amq-online-name}
-|link:hhttps://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html/release_notes_for_amq_online_1.3_on_openshift/index[{amq-online-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html/release_notes_for_amq_online_1.3_on_openshift/index[{amq-online-version}]
 
 |{three-scale-name}
 |link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.7/html/release_notes_for_red_hat_3scale_api_management_2.7_on-premises/index[{three-scale-version}]

--- a/modules/ROOT/pages/_partials/rn-versions-ref.adoc
+++ b/modules/ROOT/pages/_partials/rn-versions-ref.adoc
@@ -14,26 +14,26 @@
 |*Documentation*
 
 |{fuse-name}
-|link:https://access.redhat.com/documentation/en-us/red_hat_fuse/7.4/html/release_notes/index[{fuse-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_fuse/7.5/html/release_notes_for_red_hat_fuse_7.5/micro-release-7.5.1[{fuse-version}]
 |{fuse-configs}
 |link:{fuse-docs}[{fuse-version}] +
 (Click Fuse Online Category)
 
 |{amq-online-name}
-|link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.4/html/amq_online_1.2_on_openshift_container_platform_release_notes/[{amq-online-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html/release_notes_for_amq_online_1.3_on_openshift/index[{amq-online-version}]
 |{amq-online-configs}
-|link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.4[{amq-online-version}] +
+|link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5[{amq-online-version}] +
 (Click AMQ Online Category)
 
 |{three-scale-name}
-|link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.6/html/release_notes/index[{three-scale-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.7/html/release_notes_for_red_hat_3scale_api_management_2.7_on-premises/index[{three-scale-version}]
 |{three-scale-configs}
 |link:{three-scale-docs}[{three-scale-version}]
 
 |{code-ready-name}
-|link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/{code-ready-version}/html/release_notes_and_known_issues/index[{code-ready-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.0/html/release_notes_and_known_issues/index[{code-ready-version}]
 |{code-ready-configs}
-|link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/{code-ready-version}/[{code-ready-version}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.0/[{code-ready-version}]
 
 
 |Red Hat Single Sign-On


### PR DESCRIPTION
Adding updated links for :
- Fuse
- Enmasse
- 3Scale
- CodeReady
- (RHSSO remains unchanged)

Based off of https://github.com/integr8ly/installation/blob/v1.6/inventories/group_vars/all/manifest.yaml