### PR TITLE
enmasse cluster name prefix

### DIFF
--- a/modules/ROOT/pages/_partials/rn-new-and-changed-ref.adoc
+++ b/modules/ROOT/pages/_partials/rn-new-and-changed-ref.adoc
@@ -31,7 +31,7 @@ This section provides general guidance on configuring {amq-online-name-short} fo
 
 . Configure {amq-online-name-short} in {PRODUCT_SHORT} as described in link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html-single/installing_and_managing_amq_online_on_openshift/index#configuring-messaging[Configuring {amq-online-name-short}].
 +
-* The name of the {amq-online-name-short} project in your cluster is `enmasse`.
+* The name of the {amq-online-name-short} project in your cluster is `openshift-enmasse`.
 +
 * You must log in to the AMQ console as `customer-admin`.
 


### PR DESCRIPTION
Added the prefix "openshift-" to the name of the enmasse cluster per comment from QE. This is apparently the naming convention on OSD and was missed in the 1.7.0 RNs review. 